### PR TITLE
SEO friendly characters escaping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on: [push]
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          check-latest: true
+
+      - run: |
+          npm ci
+          npm run build
+          npm test

--- a/index.mjs
+++ b/index.mjs
@@ -1,15 +1,12 @@
 const ENTITIES = {
-  '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;',
+  '&': '&amp;',
   '"': '&quot;',
-  "'": '&#39;',
-  '/': '&#x2F;',
-  '`': '&#x60;',
-  '=': '&#x3D;'
+  "'": '&#x27;'
 }
 
-const ENT_REGEX = /<|>|&|"|'|\/|=|`/g
+const ENT_REGEX = /<|>|&|"|'/g
 
 const $getEntity = char => ENTITIES[char]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "escape-html-template",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "escape-html-template",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "rollup": "2.28.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "escape-html-template",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tag literal strings with this function to html escape interpolated values",
   "main": "index.js",
   "module": "index.mjs",
   "scripts": {
     "test": "standard && node test",
-    "prepublish": "rollup index.mjs --file index.js --format cjs --exports named --no-esModule --footer 'module.exports = Object.assign(exports.default, exports);'"
+    "build": "rollup index.mjs --file index.js --format cjs --exports named --no-esModule --footer 'module.exports = Object.assign(exports.default, exports);'",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -14,10 +14,7 @@ assert.strictEqual(String(H`${'&'}`), '&amp;')
 assert.strictEqual(String(H`${'<'}`), '&lt;')
 assert.strictEqual(String(H`${'>'}`), '&gt;')
 assert.strictEqual(String(H`${'"'}`), '&quot;')
-assert.strictEqual(String(H`${"'"}`), '&#39;')
-assert.strictEqual(String(H`${'/'}`), '&#x2F;')
-assert.strictEqual(String(H`${'`'}`), '&#x60;')
-assert.strictEqual(String(H`${'='}`), '&#x3D;')
+assert.strictEqual(String(H`${"'"}`), '&#x27;')
 
 // flattening arrays
 assert.strictEqual(String(H`${['a', 1, '<']}`), 'a1&lt;')


### PR DESCRIPTION
Current escaping mechanism creates SEO unfriendly links like:
```
https:&#x2F;&#x2F;allegro.pl&#x2F;kategoria&#x2F;akcesoria-laptop-pc-kamery-internetowe-260021?utm_source&#x3D;allegro_internal
```
which are not recognized by GoogleBot.
Current escape characters are in alignment with OWASP recommendation https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-1-html-encode-before-inserting-untrusted-data-into-html-element-content